### PR TITLE
Implement browser download flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,16 @@
 # React URL Downloader
 
-This project provides a simple React-based interface to download a file from a given URL to a specific location on the server.
+This project provides a simple React-based interface to download a file from a given URL directly to your computer.
 
 ## Structure
 
-- `server/` – Express server that performs the actual download.
-- `client/` – Minimal React frontend that sends the download request.
+- `client/` – Minimal React frontend that fetches the file and lets the browser download it.
+- `server/` – (Optional) Express server used in the original version to download files on the server.
 
 ## Usage
 
-1. Install server dependencies:
-   ```bash
-   cd server && npm install
-   npm start
-   ```
-2. Serve the client (for example using `serve` or any static server) and open `client/index.html` in your browser.
-3. Enter the URL to download and the path where the file should be saved on the server.
+1. Serve the client (for example using `serve` or any static server) and open `client/index.html` in your browser.
+2. Enter the URL to download and click **Download**. Your browser will ask for a location to save the file.
 
-Ensure the server has permission to write to the specified path.
+The previous server-based downloader remains in the `server/` folder if you still need that functionality.
+When running the server, it reads the `PORT` value from a `.env` file if present, defaulting to `5000`.

--- a/client/app.jsx
+++ b/client/app.jsx
@@ -1,6 +1,5 @@
 function App() {
   const [url, setUrl] = React.useState('');
-  const [path, setPath] = React.useState('');
   const [message, setMessage] = React.useState('');
   const [isError, setIsError] = React.useState(false);
 
@@ -8,14 +7,18 @@ function App() {
     setMessage('');
     setIsError(false);
     try {
-      const res = await fetch('http://localhost:5000/download', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url, savePath: path })
-      });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || 'Error');
-      setMessage(data.message);
+      const res = await fetch(url);
+      if (!res.ok) throw new Error('Failed to fetch file');
+      const blob = await res.blob();
+      const a = document.createElement('a');
+      a.href = window.URL.createObjectURL(blob);
+      a.download = url.split('/').pop() || 'download';
+      a.style.display = 'none';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(a.href);
+      setMessage('Download started');
     } catch (err) {
       setIsError(true);
       setMessage(err.message);
@@ -33,16 +36,6 @@ function App() {
           placeholder="https://example.com/file.zip"
           value={url}
           onChange={e => setUrl(e.target.value)}
-        />
-      </div>
-      <div className="mb-3">
-        <label className="form-label">Save Path on Server</label>
-        <input
-          type="text"
-          className="form-control"
-          placeholder="/path/to/file.zip"
-          value={path}
-          onChange={e => setPath(e.target.value)}
         />
       </div>
       <button className="btn btn-primary" onClick={handleDownload}>Download</button>

--- a/server/README.md
+++ b/server/README.md
@@ -9,4 +9,10 @@ npm install
 npm start
 ```
 
-The server listens on port 5000 by default.
+Create a `.env` file to override the default port:
+
+```bash
+PORT=3000
+```
+
+The server listens on port `5000` if no `PORT` is specified.

--- a/server/index.js
+++ b/server/index.js
@@ -3,6 +3,7 @@ const fetch = require('node-fetch');
 const fs = require('fs');
 const path = require('path');
 const cors = require('cors');
+require('dotenv').config();
 
 const app = express();
 app.use(cors());

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "express": "^4.18.2",
     "node-fetch": "^2.6.1",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.1"
   },
   "scripts": {
     "start": "node index.js"


### PR DESCRIPTION
## Summary
- remove server save path field from React UI
- fetch the file and trigger a browser download instead of using the server
- document new behavior in README
- use `dotenv` so the server picks up the `PORT` value from `.env`

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68866f2ebec8832784b79332ad1bd65e