### PR TITLE
Improve error message for CORS issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,7 @@ This project provides a simple React-based interface to download a file from a g
 1. Serve the client (for example using `serve` or any static server) and open `client/index.html` in your browser.
 2. Enter the URL to download and click **Download**. Your browser will ask for a location to save the file.
 
+If the request completes in the Network tab but the app shows `Failed to fetch`, the target server likely does not permit cross-origin downloads. In that case run the Node server in `server/` or enable CORS on the remote server.
+
 The previous server-based downloader remains in the `server/` folder if you still need that functionality.
 When running the server, it reads the `PORT` value from a `.env` file if present, defaulting to `5000`.

--- a/client/app.jsx
+++ b/client/app.jsx
@@ -21,7 +21,13 @@ function App() {
       setMessage('Download started');
     } catch (err) {
       setIsError(true);
-      setMessage(err.message);
+      if (err instanceof TypeError && err.message === 'Failed to fetch') {
+        setMessage(
+          'Failed to fetch file. The server might not allow cross-origin requests.'
+        );
+      } else {
+        setMessage(err.message);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- improve the error shown when a fetch fails
- document CORS issue in the README

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_688673b00e648327b76c7d0b0941757f