### PR TITLE
Allow CORS for all origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,7 @@ This project provides a simple React-based interface to download a file from a g
 
 If the request completes in the Network tab but the app shows `Failed to fetch`, the target server likely does not permit cross-origin downloads. In that case run the Node server in `server/` or enable CORS on the remote server.
 
+The provided Express server already enables `CORS` with `origin: '*'`, which allows requests from any site. Use it as a proxy if the remote host does not send the proper headers.
+
 The previous server-based downloader remains in the `server/` folder if you still need that functionality.
 When running the server, it reads the `PORT` value from a `.env` file if present, defaulting to `5000`.

--- a/server/index.js
+++ b/server/index.js
@@ -6,7 +6,8 @@ const cors = require('cors');
 require('dotenv').config();
 
 const app = express();
-app.use(cors());
+// Allow requests from any origin so the downloader can be used cross-site
+app.use(cors({ origin: '*' }));
 app.use(express.json());
 
 app.post('/download', async (req, res) => {


### PR DESCRIPTION
## Summary
- configure Express server's CORS middleware to allow requests from any origin
- document that the server already enables CORS for all sites

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6886768e9b8483279650c6d6deae1f8b