### PR TITLE
Allow all sites via proxy download

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ This project provides a simple React-based interface to download a file from a g
 
 ## Usage
 
-1. Serve the client (for example using `serve` or any static server) and open `client/index.html` in your browser.
-2. Enter the URL to download and click **Download**. Your browser will ask for a location to save the file.
+1. In `server/` run `npm install` and `npm start` to launch the proxy server.
+2. Serve the client (for example using `serve` or any static server) and open `client/index.html` in your browser.
+3. Enter the URL to download and click **Download**. Your browser will ask for a location to save the file.
 
-If the request completes in the Network tab but the app shows `Failed to fetch`, the target server likely does not permit cross-origin downloads. In that case run the Node server in `server/` or enable CORS on the remote server.
+The client always downloads files through the Node server's `/proxy` endpoint. This works even when the target server does not send CORS headers. The Express server already enables `CORS` with `origin: '*'`, so it can be accessed from any site.
 
 The previous server-based downloader remains in the `server/` folder if you still need that functionality.
 When running the server, it reads the `PORT` value from a `.env` file if present, defaulting to `5000`.

--- a/client/app.jsx
+++ b/client/app.jsx
@@ -7,7 +7,10 @@ function App() {
     setMessage('');
     setIsError(false);
     try {
-      const res = await fetch(url);
+      // Use the local server as a proxy so downloads work even when the remote host blocks CORS
+      const res = await fetch(
+        `http://localhost:5000/proxy?url=${encodeURIComponent(url)}`
+      );
       if (!res.ok) throw new Error('Failed to fetch file');
       const blob = await res.blob();
       const a = document.createElement('a');

--- a/server/README.md
+++ b/server/README.md
@@ -1,6 +1,6 @@
 # Downloader Server
 
-Simple Express server with an endpoint to download a file from a URL to a specified path.
+Simple Express server that can either save a remote file to disk or proxy it back to the browser.
 
 ## Setup
 
@@ -16,3 +16,9 @@ PORT=3000
 ```
 
 The server listens on port `5000` if no `PORT` is specified.
+
+### Proxy endpoint
+
+`GET /proxy?url=<fileUrl>`
+
+Fetches the file at `fileUrl` and streams it back to the client. Use this when the remote server does not allow CORS.

--- a/server/index.js
+++ b/server/index.js
@@ -6,8 +6,34 @@ const cors = require('cors');
 require('dotenv').config();
 
 const app = express();
-app.use(cors());
+// Allow requests from any origin so the downloader can be used cross-site
+app.use(cors({ origin: '*' }));
 app.use(express.json());
+
+// Proxy endpoint to work around remote servers that do not send CORS headers
+app.get('/proxy', async (req, res) => {
+  const { url } = req.query;
+  if (!url) {
+    return res.status(400).json({ error: 'url query parameter required' });
+  }
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      return res.status(response.status).end();
+    }
+    res.setHeader(
+      'Content-Type',
+      response.headers.get('content-type') || 'application/octet-stream'
+    );
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="${path.basename(url)}"`
+    );
+    response.body.pipe(res);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
 
 app.post('/download', async (req, res) => {
   const { url, savePath } = req.body;


### PR DESCRIPTION
## Summary
- add `/proxy` endpoint that streams a remote file back to the client
- update the React app to download files through the new proxy
- document using the server as a CORS proxy in the project README
- document `/proxy` usage in the server README

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6886768e9b8483279650c6d6deae1f8b