### PR TITLE
Add footer version and persist URL

### DIFF
--- a/client/app.jsx
+++ b/client/app.jsx
@@ -1,7 +1,17 @@
 function App() {
-  const [url, setUrl] = React.useState('');
+  const [url, setUrl] = React.useState(() =>
+    localStorage.getItem('downloadUrl') || ''
+  );
   const [message, setMessage] = React.useState('');
   const [isError, setIsError] = React.useState(false);
+  const [version, setVersion] = React.useState('');
+
+  React.useEffect(() => {
+    fetch('http://localhost:5000/version')
+      .then(res => res.json())
+      .then(data => setVersion(data.version))
+      .catch(() => {});
+  }, []);
 
   const handleDownload = async () => {
     setMessage('');
@@ -44,7 +54,10 @@ function App() {
           className="form-control"
           placeholder="https://example.com/file.zip"
           value={url}
-          onChange={e => setUrl(e.target.value)}
+          onChange={e => {
+            setUrl(e.target.value);
+            localStorage.setItem('downloadUrl', e.target.value);
+          }}
         />
       </div>
       <button className="btn btn-primary" onClick={handleDownload}>Download</button>
@@ -56,6 +69,9 @@ function App() {
           {message}
         </div>
       )}
+      <footer className="mt-5 text-center text-muted">
+        v{version} - Mustafa Evleksiz tarafından geliştirilmiştir
+      </footer>
     </div>
   );
 }

--- a/server/README.md
+++ b/server/README.md
@@ -22,3 +22,9 @@ The server listens on port `5000` if no `PORT` is specified.
 `GET /proxy?url=<fileUrl>`
 
 Fetches the file at `fileUrl` and streams it back to the client. Use this when the remote server does not allow CORS.
+
+### Version endpoint
+
+`GET /version`
+
+Returns the current server version from `package.json`.

--- a/server/index.js
+++ b/server/index.js
@@ -10,6 +10,12 @@ const app = express();
 app.use(cors({ origin: '*' }));
 app.use(express.json());
 
+// Endpoint to expose application version
+app.get('/version', (req, res) => {
+  const pkg = require('./package.json');
+  res.json({ version: pkg.version });
+});
+
 // Proxy endpoint to work around remote servers that do not send CORS headers
 app.get('/proxy', async (req, res) => {
   const { url } = req.query;


### PR DESCRIPTION
## Summary
- keep last used URL in localStorage
- fetch server version and show in footer with attribution
- expose `/version` endpoint in server
- document new version endpoint

## Testing
- `node --check server/index.js`
- `curl -s http://localhost:5000/version`

------
https://chatgpt.com/codex/tasks/task_e_68867f0057f88327adf3a4a61f7c1f28