### PR TITLE
Update default video URL

### DIFF
--- a/client/app.jsx
+++ b/client/app.jsx
@@ -1,6 +1,8 @@
 function App() {
+  const DEFAULT_URL =
+    'https://raw.githubusercontent.com/mediaelement/mediaelement-files/master/big_buck_bunny.mp4';
   const [url, setUrl] = React.useState(() =>
-    localStorage.getItem('downloadUrl') || ''
+    localStorage.getItem('downloadUrl') || DEFAULT_URL
   );
   const [message, setMessage] = React.useState('');
   const [isError, setIsError] = React.useState(false);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "downloader-server",
-  "version": "1.0.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "downloader-server",
-      "version": "1.0.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",
+        "dotenv": "^16.4.1",
         "express": "^4.18.2",
         "node-fetch": "^2.6.1"
       }
@@ -170,6 +171,18 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "downloader-server",
-  "version": "1.0.0",
+  "version": "0.1.1",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Summary
- set GitHub-hosted sample video as the default
- maintain server version at 0.1.1

## Testing
- `npm install` in `server`
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_6886823313e083279a8b352189d44ec3